### PR TITLE
Define config

### DIFF
--- a/src/SubscriptionServiceProvider.php
+++ b/src/SubscriptionServiceProvider.php
@@ -16,7 +16,7 @@ class SubscriptionServiceProvider extends ServiceProvider
 
         $this->publishes([
             __DIR__ . '/stubs/migration-base.stub' => database_path('migrations/2023_01_01_000000_create_base_subscription_tables.php'),
-        ], 'migrations');
+        ], 'payavel-migrations');
     }
 
     public function register()

--- a/src/SubscriptionServiceProvider.php
+++ b/src/SubscriptionServiceProvider.php
@@ -8,6 +8,10 @@ class SubscriptionServiceProvider extends ServiceProvider
 {
     public function boot()
     {
+        $this->publishes([
+            __DIR__ . '/stubs/config-publish.stub' => config_path('subscription.php'),
+        ], 'payavel-config');
+
         $this->loadMigrationsFrom(__DIR__ . '/database/migrations');
 
         $this->publishes([
@@ -17,6 +21,9 @@ class SubscriptionServiceProvider extends ServiceProvider
 
     public function register()
     {
-        // Register something...
+        $this->mergeConfigFrom(
+            __DIR__ . '/config/subscription.php',
+            'subscription'
+        );
     }
 }

--- a/src/config/subscription.php
+++ b/src/config/subscription.php
@@ -1,0 +1,32 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Subscription Test Mode
+    |--------------------------------------------------------------------------
+    |
+    | When set to true, the provider is loaded into the fake subscription gateway which
+    | will allow you to mock responses without having to initiate any http requests.
+    | This is recommended when running the application in a testing environment.
+    |
+    */
+    'test_mode' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Subscription Service Drivers
+    |--------------------------------------------------------------------------
+    |
+    | You may register custom subscription drivers and/or remove the default ones.
+    | Note that in order for the driver to be compatible it must extend
+    | the \Payavel\Subscription\SubscriptionServiceDriver::class.
+    |
+    */
+    'drivers' => [
+        'config' => \Payavel\Subscription\Drivers\ConfigDriver::class,
+        'database' => \Payavel\Subscription\Drivers\DatabaseDriver::class,
+    ],
+
+];

--- a/src/stubs/config-publish.stub
+++ b/src/stubs/config-publish.stub
@@ -1,0 +1,67 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Subscription Defaults
+    |--------------------------------------------------------------------------
+    |
+    | Here you should specify the subscription service driver that will be used
+    | within your application along with your preferred subscription provider.
+    | By default it is set to use the payavel provider via the config driver.
+    |
+    */
+    'defaults' => [
+        'driver' => 'config',
+        'provider' => 'payavel',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Subscription Test Mode
+    |--------------------------------------------------------------------------
+    |
+    | When set to true, the provider is loaded into the fake subscription gateway which
+    | will allow you to mock responses without having to initiate any http requests.
+    | This is recommended when running the application in a testing environment.
+    |
+    */
+    'test_mode' => env('SUBSCRIPTION_TEST_MODE', false),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Subscription Provider Configurations
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify the location of your subscription provider request &
+    | response classes along with any necessary env variables. By default, the
+    | payavel provider is used to manage your application's subscriptions.
+    |
+    */
+    'providers' => [
+
+        'payavel' => [
+            'name' => 'Payavel',
+            'request_class' => Payavel\Subscription\Services\Subscription\PayavelSubscriptionRequest::class,
+            'response_class' => Payavel\Subscription\Services\Subscription\PayavelSubscriptionResponse::class,
+        ],
+
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Subscription Models
+    |--------------------------------------------------------------------------
+    |
+    | This option allows you to override the models to be used for managing subscriptions.
+    | You may define your own models that extend the ones of the package in order to
+    | keep your relationships in sync with your own models.
+    |
+    */
+    // 'models' => [
+    //     \Payavel\Subscription\Models\SubscriptionProduct::class => \App\Models\Subscription\SubscriptionProduct::class,
+    //     \Payavel\Subscription\Models\Subscription::class => \App\Models\Subscription\Subscription::class,
+    // ],
+
+];


### PR DESCRIPTION
### **What does this PR do?** :robot:
- Adds publishable `config/subscription.php`.
- Adds default (merged) `subscription.php` config.

### **How should this be tested?** :microscope:
In you Laravel application:
1. `composer require payavel/subscription:dev-config`
2. `php artisan vendor:publish --provider='Payavel\Subscription\SubscriptionServiceProvider'`
3. Make sure config has been published and tinker with the merged config.
