### PR TITLE
Add `setUp()` to response.

### DIFF
--- a/src/SubscriptionResponse.php
+++ b/src/SubscriptionResponse.php
@@ -71,6 +71,8 @@ abstract class SubscriptionResponse implements SubscriptionResponder
     {
         $this->rawResponse = $rawResponse;
         $this->additionalInformation = $additionalInformation;
+
+        $this->setUp();
     }
 
     /**

--- a/src/SubscriptionResponse.php
+++ b/src/SubscriptionResponse.php
@@ -74,6 +74,16 @@ abstract class SubscriptionResponse implements SubscriptionResponder
     }
 
     /**
+     * Set up the response.
+     *
+     * @return void
+     */
+    protected function setUp()
+    {
+        //
+    }
+
+    /**
      * Configure the response based on the request.
      *
      * @param string $requestMethod

--- a/src/stubs/subscription-response.stub
+++ b/src/stubs/subscription-response.stub
@@ -7,6 +7,16 @@ use Payavel\Subscription\SubscriptionResponse;
 class {{ name }}SubscriptionResponse extends SubscriptionResponse
 {
     /**
+     * Set up the response.
+     *
+     * @return void
+     */
+    protected function setUp()
+    {
+        //
+    }
+
+    /**
      * Determines the status code based on the request's raw response.
      *
      * @return int


### PR DESCRIPTION
### **What does this PR do?** :robot:
Similar to the `SubscriptionRequest::class`, now we have a `setUp()` function in the `SubscriptionResponse::class` that is called in the `__construct()` method.

### **Does this relate to any issue?** :link:
Closes #13 
