### PR TITLE
Rename relationship column to existing one.

### DIFF
--- a/src/Models/SubscriptionAccount.php
+++ b/src/Models/SubscriptionAccount.php
@@ -58,6 +58,6 @@ class SubscriptionAccount extends Model
      */
     public function subscriptions()
     {
-        return $this->hasMany(config('subscription.models.' . Subscription::class, Subscription::class), 'customer_id');
+        return $this->hasMany(config('subscription.models.' . Subscription::class, Subscription::class), 'account_id');
     }
 }


### PR DESCRIPTION
### **What does this PR do?** :robot:
- Renames the legacy `customer_id` column to `account_id` in the `subscriptions()`relation of the `SubscriptionAccount::class` model.
